### PR TITLE
Should fix TypeError(purpose)

### DIFF
--- a/plugins/module_utils/elastic_common.py
+++ b/plugins/module_utils/elastic_common.py
@@ -73,7 +73,7 @@ class ElasticHelpers():
         # CA file has been provided. Add it to auth dict
         if module.params['cafile'] is not None:
             from ssl import create_default_context
-            context = create_default_context(module.params['cafile'])
+            context = create_default_context(cafile=module.params['cafile'])
             auth["ssl_context"] = context
 
         return auth


### PR DESCRIPTION
Got TypeError(purpose) while trying to use a cafile. Experimented directly with ssl.create_default_context(ca_file_path). Hints for how to provide an integration test would be nice. Any tips which test to use as a starting point?